### PR TITLE
0.3.0

### DIFF
--- a/example.py
+++ b/example.py
@@ -1,14 +1,15 @@
-from ollm import Inference, KVCache, file_get_contents
+from ollm import Inference, file_get_contents, TextStreamer
 
 o = Inference("llama3-1B-chat", device="cuda:0") #llama3-1B-chat(3B, 8B) | gpt-oss-20B
 o.ini_model(models_dir="/media/mega4alik/ssd/models/", force_download=False)
 o.offload_layers_to_cpu(layers_num=2) #offload some layers to CPU for speed increase
-past_key_values = KVCache(cache_dir="/media/mega4alik/ssd/kv_cache/", stats=o.stats)
+past_key_values = o.DiskCache(cache_dir="/media/mega4alik/ssd/kv_cache/")
+text_streamer = TextStreamer(o.tokenizer, skip_prompt=True, skip_special_tokens=False)
 
 sm, um = "You are helpful AI assistant", "List planets starting from Mercury"
 #sm, um = file_get_contents("./samples/85k_sample.txt"), "What's common between these articles?"
 messages = [{"role":"system", "content":sm}, {"role":"user", "content":um}]
 input_ids = o.tokenizer.apply_chat_template(messages, tokenize=True, add_generation_prompt=True, return_tensors="pt").to(o.device)
-outputs = o.model.generate(input_ids=input_ids,  past_key_values=past_key_values, max_new_tokens=20).cpu()
+outputs = o.model.generate(input_ids=input_ids,  past_key_values=past_key_values, max_new_tokens=100, streamer=text_streamer).cpu()
 answer = o.tokenizer.decode(outputs[0][input_ids.shape[-1]:], skip_special_tokens=False)
 print(answer)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ollm"
-version = "0.2.1"
-description = " LLM Inference for Large-Context Offline Workloads"
+version = "0.3.0"
+description = "LLM Inference for Large-Context Offline Workloads"
 authors = [
   { name="Anuar Sharafudinov", email="anuarsh@ailabs.us" }
 ]
@@ -14,8 +14,8 @@ license = { file="LICENSE" }
 requires-python = ">=3.10"
 dependencies = [
     "numpy",
-    "torch", #tested: 2.6.0, 2.8.0
-    "transformers>=4.55.0,<4.56.0", #tested: 4.55.4(new)
+    "torch>2.6.0", #tested: 2.8.0
+    "transformers>=4.55.0", #tested: 4.55.4, 4.56.1
     "accelerate",
     "flash-attn" #tested: 2.7.4.post1
 ]

--- a/scripts/full_tests.py
+++ b/scripts/full_tests.py
@@ -1,0 +1,49 @@
+from ollm import Inference, KVCache, file_get_contents
+import torch, os
+from datetime import datetime
+from transformers import TextStreamer, DynamicCache
+
+def run_test(test_id, model_id, sm, um, past_key_values=None, offload_layers_to_cpu=0, max_new_tokens=500):
+	o = Inference(model_id, device="cuda:0")
+	o.ini_model(models_dir="/media/mega4alik/ssd/models/", force_download=False)
+	o.offload_layers_to_cpu(layers_num=offload_layers_to_cpu)	
+	if past_key_values and isintance(past_key_values, KVCache): past_key_values.stats = o.stats
+	model, tokenizer, device = o.model, o.tokenizer, o.device
+
+	messages = [{"role":"system", "content":sm}, {"role":"user", "content":um}]
+	input_ids = tokenizer.apply_chat_template(messages, tokenize=True, reasoning_effort="minimal", add_generation_prompt=True, return_tensors="pt", return_dict=False).to(device)
+	text_streamer = TextStreamer(tokenizer, skip_prompt=True, skip_special_tokens=False)
+	with torch.no_grad():
+		print(f"\n\n#{test_id}.TestingStarted.{model_id}", datetime.now().strftime("%H:%M:%S"), "input_ids.shape:", input_ids.shape)
+		outputs = model.generate(input_ids=input_ids, max_new_tokens=max_new_tokens, do_sample=False, past_key_values=past_key_values, use_cache=True, streamer=text_streamer).detach().cpu()
+		answer = tokenizer.decode(outputs[0][input_ids.shape[-1]:], skip_special_tokens=False)
+		print(answer)
+		return answer
+
+
+#=======================================================
+test_ids = [3,2,1]
+cache_dir = "/media/mega4alik/ssd/kv_cache/"
+
+for test_id in test_ids:
+	if test_id==1: #1. Llama3-8B check noKV==newKV2.0 on 10k_chats
+		sm, um = "[CHATS]:\n"+file_get_contents("./samples/10k_sample.txt")+"[/END CHATS]", "Analyze chats above and write top 10 most popular questions (translate to english)."
+		ans1 = run_test("1-1", "llama3-8B-chat", sm, um, past_key_values=None)
+		past_key_values = KVCache(cache_dir=cache_dir)
+		ans2 = run_test("1-2", "llama3-8B-chat", sm, um, past_key_values=past_key_values, offload_layers_to_cpu=2)
+		if ans1!=ans2: print(f"#1.TestFailed <1.ans1>:\n{ans2}\n<1.ans2>:\n{ans2}")
+		else: print("#1.TestSuccess")
+
+	if test_id==2: #2. gpt-oss-20B check noKV==newKV2.0 on 2k_sample	
+		sm, um = "[CHATS]:\n"+file_get_contents("./samples/2k_sample.txt")+"[/END CHATS]", "Analyze chats above and write top 10 most popular questions (translate to english)."
+		ans1 = run_test("2-1", "gpt-oss-20B", sm, um, past_key_values=None)
+		past_key_values = KVCache(cache_dir=cache_dir)
+		ans2 = run_test("2-2", "gpt-oss-20B", sm, um, past_key_values=past_key_values, offload_layers_to_cpu=6)
+		if ans1!=ans2: print(f"#2.TestFailed <2.ans1>:\n{ans2}\n<2.ans2>:\n{ans2}")
+		else: print("#2.TestSuccess")
+
+	if test_id==3: #3. Llama3-8B newKV2.0, make sure it runs without OOM on 85k_sample
+		sm, um = file_get_contents("./samples/85k_sample.txt"), "Analyze papers above and find 3 common similarities."
+		past_key_values = KVCache(cache_dir=cache_dir)
+		ans = run_test("3", "llama3-8B-chat", sm, um, past_key_values=past_key_values, offload_layers_to_cpu=0, max_new_tokens=100)
+		print("#3.TestSuccess")

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -9,33 +9,33 @@ from datetime import datetime
 from transformers import AutoTokenizer, TextStreamer
 
 def inference_chat():
-	#sm, um, max_new_tokens = "You are helpful AI assistant", "List planets starting from Mercury", 20
-	sm, um, max_new_tokens = "[CHATS]:\n"+file_get_contents("./temp/chats.txt")+"[/END CHATS]", "Analyze chats above and write top 10 most popular questions (translate to english).", 500
+	sm, um, max_new_tokens = "You are helpful AI assistant", "List planets starting from Mercury", 100
+	#sm, um, max_new_tokens = "[CHATS]:\n"+file_get_contents("./samples/10k_sample.txt")+"[/END CHATS]", "Analyze chats above and write top 10 most popular questions (translate to english).", 500
 	messages = [{"role":"system", "content":sm}, {"role":"user", "content":um}]	
-	inputs = tokenizer.apply_chat_template(messages, tokenize=True, add_generation_prompt=True, return_tensors="pt", return_dict=True).to(device)
+	input_ids = tokenizer.apply_chat_template(messages, tokenize=True, reasoning_effort="minimal", add_generation_prompt=True, return_tensors="pt", return_dict=False).to(device)
 	text_streamer = TextStreamer(tokenizer, skip_prompt=True, skip_special_tokens=False)
 	with torch.no_grad():
-		past_key_values = KVCache(cache_dir="/media/mega4alik/ssd/kv_cache/", stats=stats)
-		print("\n\nGenerate started.", datetime.now().strftime("%H:%M:%S"), "input_ids.shape:", inputs.input_ids.shape)
-		outputs = model.generate(**inputs, max_new_tokens=max_new_tokens, do_sample=False, past_key_values=past_key_values, use_cache=True, streamer=text_streamer).detach().cpu()
-		answer = tokenizer.decode(outputs[0][inputs.input_ids.shape[-1]:], skip_special_tokens=False)
+		past_key_values = None #KVCache(cache_dir="/media/mega4alik/ssd/kv_cache/", stats=stats)
+		print("\n\nGenerate started.", datetime.now().strftime("%H:%M:%S"), "input_ids.shape:", input_ids.shape)
+		outputs = model.generate(input_ids=input_ids, max_new_tokens=max_new_tokens, do_sample=False, past_key_values=past_key_values, use_cache=True, streamer=text_streamer).detach().cpu()
+		answer = tokenizer.decode(outputs[0][input_ids.shape[-1]:], skip_special_tokens=False)
 		print(answer)
 
 
 #=======================================================
 if 1==1:
 	device = torch.device("cuda:0")
-	model_dir = "/media/mega4alik/ssd/models/llama3-8B-chat/"
+	model_dir = "/media/mega4alik/ssd/models/gpt-oss-20B/"
 	print("loading", model_dir)
-	llama.loader = GDSWeights(model_dir+"gds_export/", device="cuda:0")
+	gpt_oss.loader = GDSWeights(model_dir+"gds_export/", device="cuda:0")
 	stats = Stats()
-	llama.stats, gds_loader.stats = stats, stats
+	gpt_oss.stats, gds_loader.stats = stats, stats
 	tokenizer = AutoTokenizer.from_pretrained(model_dir)
-	model = llama.MyLlamaForCausalLM.from_pretrained(model_dir, torch_dtype=torch.float16, device_map="cpu", low_cpu_mem_usage=True, ignore_mismatched_sizes=True, attn_implementation="flash_attention_2")
-	model.clean_layers_weights()
+	model = MyGptOssForCausalLM.from_pretrained(model_dir, torch_dtype=torch.bfloat16, device_map="cpu", low_cpu_mem_usage=True, ignore_mismatched_sizes=True) #, attn_implementation="flash_attention_2"
+	#model.clean_layers_weights()
 	model.eval()
 	model.to(device)
-	#model.offload_layers_to_cpu(layers_num=1)
+	#model.offload_layers_to_cpu(layers_num=12)
 	inference_chat()
 
 elif 2==0:

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -6,11 +6,11 @@ from ollm import gpt_oss, gds_loader, llama
 
 import torch, os
 from datetime import datetime
-from transformers import AutoTokenizer, TextStreamer
+from transformers import AutoTokenizer, TextStreamer, DynamicCache
 
 def inference_chat():
-	#sm, um, max_new_tokens = "You are helpful AI assistant", "List planets starting from Mercury", 100
-	sm, um, max_new_tokens = "[CHATS]:\n"+file_get_contents("./samples/10k_sample.txt")+"[/END CHATS]", "Analyze chats above and write top 10 most popular questions (translate to english).", 500
+	sm, um, max_new_tokens = "You are helpful AI assistant", "List planets starting from Mercury", 100
+	#sm, um, max_new_tokens = "[CHATS]:\n"+file_get_contents("./samples/2k_sample.txt")+"[/END CHATS]", "Analyze chats above and write top 10 most popular questions (translate to english).", 500
 	messages = [{"role":"system", "content":sm}, {"role":"user", "content":um}]
 	input_ids = tokenizer.apply_chat_template(messages, tokenize=True, reasoning_effort="minimal", add_generation_prompt=True, return_tensors="pt", return_dict=False).to(device)
 	text_streamer = TextStreamer(tokenizer, skip_prompt=True, skip_special_tokens=False)

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -1,7 +1,8 @@
-from ollm import Inference, KVCache, file_get_contents
+from ollm import Inference, file_get_contents
 from ollm.gds_loader import GDSWeights
-from ollm.gpt_oss import MyGptOssForCausalLM
 from ollm.utils import Stats
+from ollm.kvcache import KVCache
+from ollm.gpt_oss import MyGptOssForCausalLM
 from ollm import gpt_oss, gds_loader, llama
 
 import torch, os
@@ -15,7 +16,7 @@ def inference_chat():
 	input_ids = tokenizer.apply_chat_template(messages, tokenize=True, reasoning_effort="minimal", add_generation_prompt=True, return_tensors="pt", return_dict=False).to(device)
 	text_streamer = TextStreamer(tokenizer, skip_prompt=True, skip_special_tokens=False)
 	with torch.no_grad():
-		past_key_values = KVCache(cache_dir="/media/mega4alik/ssd/kv_cache/", stats=stats)
+		past_key_values = KVCache(cache_dir="/media/mega4alik/ssd/kv_cache/")
 		print("\n\nGenerate started.", datetime.now().strftime("%H:%M:%S"), "input_ids.shape:", input_ids.shape)
 		outputs = model.generate(input_ids=input_ids, max_new_tokens=max_new_tokens, do_sample=False, past_key_values=past_key_values, use_cache=True, streamer=text_streamer).detach().cpu()
 		answer = tokenizer.decode(outputs[0][input_ids.shape[-1]:], skip_special_tokens=False)

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -9,18 +9,17 @@ from datetime import datetime
 from transformers import AutoTokenizer, TextStreamer
 
 def inference_chat():
-	sm, um, max_new_tokens = "You are helpful AI assistant", "List planets starting from Mercury", 100
-	#sm, um, max_new_tokens = "[CHATS]:\n"+file_get_contents("./samples/10k_sample.txt")+"[/END CHATS]", "Analyze chats above and write top 10 most popular questions (translate to english).", 500
-	messages = [{"role":"system", "content":sm}, {"role":"user", "content":um}]	
+	#sm, um, max_new_tokens = "You are helpful AI assistant", "List planets starting from Mercury", 100
+	sm, um, max_new_tokens = "[CHATS]:\n"+file_get_contents("./samples/10k_sample.txt")+"[/END CHATS]", "Analyze chats above and write top 10 most popular questions (translate to english).", 500
+	messages = [{"role":"system", "content":sm}, {"role":"user", "content":um}]
 	input_ids = tokenizer.apply_chat_template(messages, tokenize=True, reasoning_effort="minimal", add_generation_prompt=True, return_tensors="pt", return_dict=False).to(device)
 	text_streamer = TextStreamer(tokenizer, skip_prompt=True, skip_special_tokens=False)
 	with torch.no_grad():
-		past_key_values = None #KVCache(cache_dir="/media/mega4alik/ssd/kv_cache/", stats=stats)
+		past_key_values = KVCache(cache_dir="/media/mega4alik/ssd/kv_cache/", stats=stats)
 		print("\n\nGenerate started.", datetime.now().strftime("%H:%M:%S"), "input_ids.shape:", input_ids.shape)
 		outputs = model.generate(input_ids=input_ids, max_new_tokens=max_new_tokens, do_sample=False, past_key_values=past_key_values, use_cache=True, streamer=text_streamer).detach().cpu()
 		answer = tokenizer.decode(outputs[0][input_ids.shape[-1]:], skip_special_tokens=False)
 		print(answer)
-
 
 #=======================================================
 if 1==1:

--- a/src/ollm/__init__.py
+++ b/src/ollm/__init__.py
@@ -1,4 +1,4 @@
 # src/ollm/__init__.py
 from .inference import Inference
-from .kvcache import KVCache
 from .utils import file_get_contents
+from transformers import TextStreamer

--- a/src/ollm/gpt_oss.py
+++ b/src/ollm/gpt_oss.py
@@ -10,7 +10,7 @@ from typing import Callable, Optional, Tuple, Union, Dict, Any, Iterable, List, 
 from transformers import GptOssForCausalLM, AutoTokenizer, AutoModelForCausalLM
 from .utils import _walk_to_parent, _assign_tensor_to_module, _set_meta_placeholder
 from .gds_loader import GDSWeights
-from .gpt_oss_attention import attention
+from .gpt_oss_attention import attention as flash_attention
 
 #global vars
 loader, stats = None, None
@@ -22,118 +22,44 @@ class MyGptOssAttention(GptOssAttention):
 	def forward(self, *args, **kwargs):
 		out = super().forward(*args, **kwargs)
 		#print(self.layer_idx, "attention:", out[0].shape)
-		return out		
+		return out
 
 
 class MyGptOssExperts(GptOssExperts):
-
-	def forward_chunked(self, hidden_states, routing_weights, chunk_size=1):
-		# shapes:
-		# hidden_states: (B, T, H)
-		# gate_up_proj: (E, 2*H, H)
-		# gate_up_proj_bias: (E, 2*H)
-		# down_proj: either shared (out_features, in_features) or per-expert (E, out, in)
-		routing_weights = routing_weights.unsqueeze(0).transpose(1,2)
-		B, T, H = hidden_states.shape
-		E = routing_weights.shape[1]
-		print(self.gate_up_proj.shape, self.gate_up_proj_bias.shape, self.down_proj.shape, "routing_weights:", routing_weights.shape)
-
-		# Prepare accumulator on same device/dtype
-		acc = torch.zeros((B, T, H), device=hidden_states.device, dtype=hidden_states.dtype)
-
-		for e in range(E):
-			# compute gate_up for expert e
-			weight_e = self.gate_up_proj[e].transpose(0,1)  # (2*H, H)
-			bias_e   = self.gate_up_proj_bias[e]     # (2*H,)
-
-			gate_up_e = F.linear(hidden_states, weight_e, bias_e)  # (B, T, 2*H)
-			gate_e = gate_up_e[..., ::2]   # (B, T, H)
-			up_e   = gate_up_e[..., 1::2]  # (B, T, H)
-
-			gate_e.clamp_(max=self.limit)
-			up_e.clamp_(min=-self.limit, max=self.limit)
-
-			glu_e = gate_e * torch.sigmoid(gate_e * self.alpha)
-			up_plus_e = up_e + 1.0
-
-			# down proj for this expert
-			if hasattr(self.down_proj, 'shape') and self.down_proj.dim() == 3:
-				# per-expert down_proj: (E, out, in)
-				down_weight_e = self.down_proj[e]         # (H, H) or (out, in)
-				down_bias_e   = self.down_proj_bias[e]
-				flat = (up_plus_e * glu_e).reshape(B*T, H)
-				down_out_e = F.linear(flat, down_weight_e, down_bias_e).view(B, T, H)
-			else:
-				# shared down_proj
-				flat = (up_plus_e * glu_e).reshape(B*T, H)
-				down_out = F.linear(flat, self.down_proj, self.down_proj_bias).view(B, T, H)
-				down_out_e = down_out  # reuse shared result
-
-			# routing weight: adapt depending on shape of routing_weights
-			# you said routing_weights (num_experts, T) earlier — adapt here:
-			# if routing_weights is (B, E, T) use routing_weights[:, e, :]
-			# if (E, T) use routing_weights[e, :].unsqueeze(0).repeat(B, 1)
-			if routing_weights.dim() == 3:
-				r_e = routing_weights[:, e, :].unsqueeze(-1)  # (B, T, 1)
-			else:
-				r_e = routing_weights[e].unsqueeze(0).unsqueeze(-1)  # (1, T, 1) -> broadcasts over B
-
-			acc += down_out_e * r_e  
-		return	acc
-
-
-	def forward_chunked2(self, hidden_states, routing_weights) -> torch.Tensor:
-		batch_size, T, H = hidden_states.shape
-		hidden_states = hidden_states.reshape(-1, self.hidden_size)  # (num_tokens, hidden_size)
+	def forward(self, hidden_states: torch.Tensor, router_indices=None, routing_weights=None) -> torch.Tensor: #chunked/looped
 		num_experts = routing_weights.shape[1]
-		hidden_states = hidden_states.repeat(num_experts, 1)
-		hidden_states = hidden_states.view(num_experts, -1, self.hidden_size)
+		batch_size, T, H = hidden_states.shape
 		acc = torch.zeros((batch_size, T, H), device=hidden_states.device, dtype=hidden_states.dtype)
-
 		for e in range(num_experts):
-			x = hidden_states[e].unsqueeze(0)
 			s_gate_up_proj = self.gate_up_proj[e].unsqueeze(0)
 			s_gate_up_proj_bias = self.gate_up_proj_bias[e].unsqueeze(0)
 			s_down_proj = self.down_proj[e].unsqueeze(0)
 			s_down_proj_bias = self.down_proj_bias[e].unsqueeze(0)
-			routing_weights_e = routing_weights[:, e:e+1]
+			routing_weights_e = routing_weights[:, e].unsqueeze(-1)
 
-			gate_up = torch.bmm(x, s_gate_up_proj) + s_gate_up_proj_bias[..., None, :]
+			gate_up = torch.bmm(hidden_states, s_gate_up_proj) + s_gate_up_proj_bias[..., None, :]
 			gate, up = gate_up[..., ::2], gate_up[..., 1::2]
 			gate = gate.clamp(min=None, max=self.limit)
 			up = up.clamp(min=-self.limit, max=self.limit)
-			glu = gate * torch.sigmoid(gate * self.alpha)			
+			glu = gate * torch.sigmoid(gate * self.alpha)
 			next_states = torch.bmm(((up + 1) * glu), s_down_proj)
 			next_states = next_states + s_down_proj_bias[..., None, :]
 			next_states = next_states.view(1, batch_size, -1, self.hidden_size)
-			next_states = next_states * routing_weights_e.transpose(0, 1).view(1, batch_size, -1)[..., None]			
-			next_states = next_states.sum(dim=0)			
+			next_states = next_states * routing_weights_e.transpose(0, 1).view(1, batch_size, -1)[..., None]
+			next_states = next_states.squeeze(0) #.sum(dim=0)
 			acc += next_states
-			#print(x.shape, s_gate_up_proj.shape, s_gate_up_proj_bias.shape, s_down_proj.shape, "routing_weights:", routing_weights_e.shape, "next_states:", next_states.shape)
-
+			#print(x.shape, s_gate_up_proj.shape, s_gate_up_proj_bias.shape, s_down_proj.shape, "routing_weights:", routing_weights_e.shape, "next_states:", next_states.shape)			
 		return acc
 
 
-	def forward(self, hidden_states: torch.Tensor, router_indices=None, routing_weights=None) -> torch.Tensor:		
-		return self.forward_chunked2(hidden_states, routing_weights) #meine
-		"""
-		When training is is more efficient to just loop over the experts and compute the output for each expert
-		as otherwise the memory would explode.
-
-		For inference we can sacrifice some memory and compute the output for all experts at once. By repeating the inputs.
-
-		Args:
-			hidden_states (torch.Tensor): (batch_size, seq_len, hidden_size)
-			selected_experts (torch.Tensor): (batch_size * token_num, top_k)
-			routing_weights (torch.Tensor): (batch_size * token_num, num_experts)
-		Returns:
-			torch.Tensor
-		"""
+	def forward_default(self, hidden_states: torch.Tensor, router_indices=None, routing_weights=None) -> torch.Tensor:
+		#t1 = self.forward_chunked(hidden_states, routing_weights=routing_weights) #chunked for comparison
+		
 		batch_size = hidden_states.shape[0]
 		hidden_states = hidden_states.reshape(-1, self.hidden_size)  # (num_tokens, hidden_size)
 		num_experts = routing_weights.shape[1]
 					
-		hidden_states = hidden_states.repeat(num_experts, 1)
+		hidden_states = hidden_states.repeat(num_experts, 1) #T,C->num_experts,T,C
 		hidden_states = hidden_states.view(num_experts, -1, self.hidden_size)
 
 		gate_up = torch.bmm(hidden_states, self.gate_up_proj) + self.gate_up_proj_bias[..., None, :]
@@ -146,6 +72,7 @@ class MyGptOssExperts(GptOssExperts):
 		next_states = next_states.view(num_experts, batch_size, -1, self.hidden_size)
 		next_states = next_states * routing_weights.transpose(0, 1).view(num_experts, batch_size, -1)[..., None]
 		next_states = next_states.sum(dim=0)
+		#print(t1.flatten()[-5:], next_states.flatten()[-5:], "maxErr:", (t1-next_states).abs().max().item(), "\n")
 		return next_states
 
 
@@ -270,7 +197,7 @@ class MyGptOssModel(GptOssModel):
 		)
 		
 
-#===
+#===============================================
 def my_eager_attention_forward(
 	module: nn.Module,
 	query: torch.Tensor,
@@ -291,7 +218,7 @@ def my_eager_attention_forward(
 	if offset==0: #use FA only for first generation
 		#print("offset", query.shape, key.shape, offset, "n_ctx:", n_ctx, "sliding_window:", sliding_window, "scaling:", scaling, kwargs)
 		start_q = torch.LongTensor([offset]).to(query.device)
-		t = attention(
+		t = flash_attention(
 			query,
 			key_states,
 			value_states,
@@ -300,7 +227,7 @@ def my_eager_attention_forward(
 			sliding_window,
 			start_q
 		)
-		attn_output, attn_weights = t, None		
+		attn_output, attn_weights = t, None
 	
 	else: #standard attention (default)
 		attn_weights = torch.matmul(query, key_states.transpose(2, 3)) * scaling
@@ -328,7 +255,7 @@ import transformers.models.gpt_oss.modeling_gpt_oss as modeling
 modeling.GptOssExperts = MyGptOssExperts
 modeling.GptOssAttention = MyGptOssAttention
 modeling.GptOssModel = MyGptOssModel
-modeling.eager_attention_forward = my_eager_attention_forward #testing
+modeling.eager_attention_forward = my_eager_attention_forward
 #===============================================
 
 

--- a/src/ollm/gpt_oss.py
+++ b/src/ollm/gpt_oss.py
@@ -10,19 +10,99 @@ from typing import Callable, Optional, Tuple, Union, Dict, Any, Iterable, List, 
 from transformers import GptOssForCausalLM, AutoTokenizer, AutoModelForCausalLM
 from .utils import _walk_to_parent, _assign_tensor_to_module, _set_meta_placeholder
 from .gds_loader import GDSWeights
-#from .attention import online_chunked_grouped_attention_rope_no_mask as chunked_attention
+from .gpt_oss_attention import attention,attention_ref
 
 #global vars
 loader, stats = None, None
 
 #======== rewriting core classess ==============
-from transformers.models.gpt_oss.modeling_gpt_oss import GptOssAttention, GptOssModel, GptOssConfig, GptOssDecoderLayer, create_causal_mask, create_sliding_window_causal_mask, repeat_kv, MoeModelOutputWithPast
+from transformers.models.gpt_oss.modeling_gpt_oss import GptOssAttention, GptOssExperts,  GptOssModel, GptOssConfig, GptOssDecoderLayer, create_causal_mask, create_sliding_window_causal_mask, repeat_kv, MoeModelOutputWithPast
 
 class MyGptOssAttention(GptOssAttention):
 	def forward(self, *args, **kwargs):
 		out = super().forward(*args, **kwargs)
 		#print(self.layer_idx, "attention:", out[0].shape)
 		return out		
+
+
+class MyGptOssExperts(GptOssExperts):
+
+	def forward_chunked(self, hidden_states, routing_weights, chunk_size=1):
+		batch_size, seq_len, hidden_dim = hidden_states.shape
+		num_experts = routing_weights.shape[0]
+
+		# Buffer for accumulating results
+		final_states = torch.zeros(batch_size, seq_len, hidden_dim, device=hidden_states.device, dtype=hidden_states.dtype)
+
+		for start in range(0, num_experts, chunk_size):
+			end = min(start + chunk_size, num_experts)
+			experts_in_chunk = end - start
+
+			# Slice the relevant experts' routing weights
+			rw_chunk = routing_weights[start:end]  # [experts_in_chunk, batch, seq]
+
+			# Expand hidden_states only for this chunk
+			hs_chunk = hidden_states.expand(experts_in_chunk, -1, -1, -1).reshape(experts_in_chunk * batch_size * seq_len, hidden_dim)
+
+			# Projections (using bmm style)
+			gate_up = torch.matmul(hs_chunk, self.gate_up_proj[start:end].reshape(experts_in_chunk, hidden_dim, -1)) \
+					  + self.gate_up_proj_bias[start:end].reshape(experts_in_chunk, -1)
+
+			gate, up = gate_up[..., ::2], gate_up[..., 1::2]
+			gate = gate.clamp(max=self.limit)
+			up = up.clamp(min=-self.limit, max=self.limit)
+
+			glu = gate * torch.sigmoid(gate * self.alpha)
+			next_states = torch.matmul(((up + 1) * glu), self.down_proj[start:end]) \
+						  + self.down_proj_bias[start:end]
+
+			# Reshape back
+			next_states = next_states.view(experts_in_chunk, batch_size, seq_len, hidden_dim)
+
+			# Apply routing weights
+			next_states = next_states * rw_chunk[..., None]
+
+			# Accumulate into buffer
+			final_states += next_states.sum(dim=0)
+
+		return final_states
+
+
+	def forward(self, hidden_states: torch.Tensor, router_indices=None, routing_weights=None) -> torch.Tensor:
+		
+		return self.forward_chunked(hidden_states, routing_weights) #meine
+		
+		"""
+		When training is is more efficient to just loop over the experts and compute the output for each expert
+		as otherwise the memory would explode.
+
+		For inference we can sacrifice some memory and compute the output for all experts at once. By repeating the inputs.
+
+		Args:
+			hidden_states (torch.Tensor): (batch_size, seq_len, hidden_size)
+			selected_experts (torch.Tensor): (batch_size * token_num, top_k)
+			routing_weights (torch.Tensor): (batch_size * token_num, num_experts)
+		Returns:
+			torch.Tensor
+		"""
+		batch_size = hidden_states.shape[0]
+		hidden_states = hidden_states.reshape(-1, self.hidden_size)  # (num_tokens, hidden_size)
+		num_experts = routing_weights.shape[1]
+					
+		hidden_states = hidden_states.repeat(num_experts, 1)
+		hidden_states = hidden_states.view(num_experts, -1, self.hidden_size)
+		gate_up = torch.bmm(hidden_states, self.gate_up_proj) + self.gate_up_proj_bias[..., None, :]
+		gate, up = gate_up[..., ::2], gate_up[..., 1::2]
+		gate = gate.clamp(min=None, max=self.limit)
+		up = up.clamp(min=-self.limit, max=self.limit)
+		glu = gate * torch.sigmoid(gate * self.alpha)
+		next_states = torch.bmm(((up + 1) * glu), self.down_proj)
+		next_states = next_states + self.down_proj_bias[..., None, :]
+		next_states = next_states.view(num_experts, batch_size, -1, self.hidden_size)
+		next_states = next_states * routing_weights.transpose(0, 1).view(num_experts, batch_size, -1)[..., None]
+		next_states = next_states.sum(dim=0)
+		return next_states
+
 
 
 class oDecoderLayer:
@@ -145,175 +225,65 @@ class MyGptOssModel(GptOssModel):
 		)
 		
 
+#===
 def my_eager_attention_forward(
-    module: nn.Module,
-    query: torch.Tensor,          # (B, Hq, Tq, D)  -- RoPE already applied upstream
-    key: torch.Tensor,            # (B, Hkv, Tk, D) -- RoPE already applied upstream
-    value: torch.Tensor,          # (B, Hkv, Tk, D)
-    attention_mask: Optional[torch.Tensor],
-    scaling: float,
-    dropout: float = 0.0,
-    q_block_size: int = 64,
-    k_block_size: int = 512,
-    return_attn_weights: bool = False,  # if True, falls back to dense path to produce weights
-    eps: float = 1e-12,
-    **kwargs,
+	module: nn.Module,
+	query: torch.Tensor,
+	key: torch.Tensor,
+	value: torch.Tensor,
+	attention_mask: Optional[torch.Tensor],
+	scaling: float,
+	dropout: float = 0.0,
+	sliding_window=None,
+	s_aux = None,
+	**kwargs,
 ):
-    """
-    Memory-efficient attention with chunked GEMM + online softmax merging.
-    Matches your original semantics:
-      - repeat_kv() to expand KV heads to Hq
-      - optional attention_mask added to logits
-      - 'sinks' logits are concatenated to keys for normalization, then dropped
-      - dropout applied to probabilities (not renormalized), exactly like F.dropout(scores)
-    Notes:
-      * For very long sequences, returning full attn_weights is impractical; default is None.
-      * RoPE/position_ids should be handled before calling this (as in your snippet).
-    """
-    device = query.device
-    dtype_in = query.dtype
-    B, Hq, Tq, D = query.shape
+	key_states = repeat_kv(key, module.num_key_value_groups)
+	value_states = repeat_kv(value, module.num_key_value_groups)	
+	
+	# Flash-attention
+	offset, n_ctx = min(key.shape[2] - query.shape[2], sliding_window if sliding_window else 999), query.shape[2]
+	if offset==0: #use FA only for first generation
+		#print("offset", query.shape, key.shape, offset, "n_ctx:", n_ctx, "sliding_window:", sliding_window, "scaling:", scaling, kwargs)
+		start_q = torch.LongTensor([offset]).to(query.device)
+		t = attention(
+			query,
+			key_states,
+			value_states,
+			s_aux, #sinks,
+			scaling,
+			sliding_window,
+			start_q
+		)
+		attn_output, attn_weights = t, None		
+	
+	else: #standard attention (default)
+		attn_weights = torch.matmul(query, key_states.transpose(2, 3)) * scaling
+		if attention_mask is not None:
+			causal_mask = attention_mask[:, :, :, : key_states.shape[-2]]
+			attn_weights = attn_weights + causal_mask
 
-    # Fast path (optional): if user explicitly wants attention weights, do the dense version.
-    if return_attn_weights:
-        key_states   = repeat_kv(key, module.num_key_value_groups)      # (B, Hq, Tk, D)
-        value_states = repeat_kv(value, module.num_key_value_groups)    # (B, Hq, Tk, D)
-        attn_weights = torch.matmul(query, key_states.transpose(2, 3)) * scaling  # (B,Hq,Tq,Tk)
-        if attention_mask is not None:
-            causal_mask = attention_mask[:, :, :, : key_states.shape[-2]]
-            attn_weights = attn_weights + causal_mask
+		sinks = module.sinks.reshape(1, -1, 1, 1).expand(query.shape[0], -1, query.shape[-2], -1)
+		combined_logits = torch.cat([attn_weights, sinks], dim=-1)
 
-        # sinks
-        sinks = module.sinks.reshape(1, -1, 1, 1).expand(B, Hq, Tq, -1)  # (B,Hq,Tq,S)
-        combined_logits = torch.cat([attn_weights, sinks], dim=-1)
-        combined_logits = combined_logits - combined_logits.max(dim=-1, keepdim=True).values
-        probs = F.softmax(combined_logits, dim=-1, dtype=combined_logits.dtype)
-        scores = probs[..., :-sinks.shape[-1]]  # drop sink columns
-        scores = F.dropout(scores, p=dropout, training=module.training)
-        attn_output = torch.matmul(scores, value_states)                 # (B,Hq,Tq,D)
-        return attn_output.transpose(1, 2).contiguous(), scores
-
-    # --------- Streaming / Chunked path ----------
-    # Repeat KV to match query heads (GQA)
-    key_states   = repeat_kv(key,   module.num_key_value_groups).to(torch.float32)   # (B,Hq,Tk,D)
-    value_states = repeat_kv(value, module.num_key_value_groups).to(torch.float32)   # (B,Hq,Tk,D)
-    query_states = query.to(torch.float32)                                           # (B,Hq,Tq,D)
-
-    B, Hq, Tk, _ = key_states.shape
-    scale = float(scaling)
-
-    # Accumulators for online softmax across key-blocks
-    # m: running max per (B,Hq,Tq), s: running sum of exp in 'm'-frame
-    m  = torch.full((B, Hq, Tq), float("-inf"), device=device, dtype=torch.float32)
-    s  = torch.zeros((B, Hq, Tq), device=device, dtype=torch.float32)
-    wv = torch.zeros((B, Hq, Tq, D), device=device, dtype=torch.float32)
-
-    # Iterate over key blocks
-    for k_start in range(0, Tk, k_block_size):
-        k_end = min(Tk, k_start + k_block_size)
-        k_blk = key_states[:, :, k_start:k_end, :]    # (B,Hq,Bk,D)
-        v_blk = value_states[:, :, k_start:k_end, :]  # (B,Hq,Bk,D)
-
-        # Optional mask slice, same semantics as your code
-        if attention_mask is not None:
-            # attention_mask shape is broadcastable to (B,Hq,Tq,Tk)
-            mask_blk = attention_mask[:, :, :, k_start:k_end]           # (B,H?,Tq,Bk)
-        else:
-            mask_blk = None
-
-        # Process query in blocks for cache-friendliness
-        for q_start in range(0, Tq, q_block_size):
-            q_end = min(Tq, q_start + q_block_size)
-            q_blk = query_states[:, :, q_start:q_end, :]                # (B,Hq,Bq,D)
-
-            # scores = (B,Hq,Bq,Bk)
-            scores = torch.einsum("b h q d, b h k d -> b h q k", q_blk, k_blk) * scale
-
-            if mask_blk is not None:
-                # Add mask (typically 0 or -inf); broadcasting over Hq if mask is (B,1,Tq,Bk)
-                scores = scores + mask_blk[:, :scores.shape[1], q_start:q_end, :]
-
-            # Local max over k for numerical stability
-            local_max = torch.amax(scores, dim=-1)                      # (B,Hq,Bq)
-
-            # exp(scores - local_max)
-            exp_scores = torch.exp(scores - local_max.unsqueeze(-1))    # (B,Hq,Bq,Bk)
-
-            # Dropout on probabilities (exactly like your original): applied BEFORE V matmul,
-            # not renormalized (F.dropout semantics).
-            if module.training and dropout > 0.0:
-                keep_p = 1.0 - dropout
-                # same shape as exp_scores; generate mask on the same device/dtype float32
-                drop_mask = (torch.rand_like(exp_scores) < keep_p).to(exp_scores.dtype) / keep_p
-                exp_scores = exp_scores * drop_mask
-                del drop_mask
-
-            sum_exp = exp_scores.sum(dim=-1)                            # (B,Hq,Bq)
-            weighted_v_chunk = torch.einsum("b h q k, b h k d -> b h q d", exp_scores, v_blk)  # (B,Hq,Bq,D)
-
-            # Merge with global accumulators (log-sum-exp merge)
-            first = torch.isinf(m[:, :, q_start:q_end])                 # (B,Hq,Bq)
-            if first.any():
-                idx = first
-                m[:, :, q_start:q_end][idx]  = local_max[idx]
-                s[:, :, q_start:q_end][idx]  = sum_exp[idx]
-                wv[:, :, q_start:q_end][idx] = weighted_v_chunk[idx]
-
-            merge = ~first
-            if merge.any():
-                m_old = m[:, :, q_start:q_end][merge]                   # (N,)
-                s_old = s[:, :, q_start:q_end][merge]                   # (N,)
-                wv_old = wv[:, :, q_start:q_end][merge]                 # (N,D)
-
-                lm_new = local_max[merge]                               # (N,)
-                se_new = sum_exp[merge]                                 # (N,)
-                wv_new = weighted_v_chunk[merge]                        # (N,D)
-
-                new_m  = torch.maximum(m_old, lm_new)
-                alpha  = torch.exp(m_old - new_m)
-                beta   = torch.exp(lm_new - new_m)
-
-                s[:, :, q_start:q_end][merge]  = s_old * alpha + se_new * beta
-                wv[:, :, q_start:q_end][merge] = wv_old * alpha.unsqueeze(-1) + wv_new * beta.unsqueeze(-1)
-                m[:, :, q_start:q_end][merge]  = new_m
-
-            # free temps
-            del scores, local_max, exp_scores, sum_exp, weighted_v_chunk, q_blk
-
-        del k_blk, v_blk, mask_blk
-
-    # ---- Merge the SINK logits (no V contribution) ----
-    # Your original concatenates sink logits to the last dim, subtracts row-max,
-    # softmax over keys+sink, then drops sink columns before matmul with V.
-    # Equivalent effect: merge sinks into the (m,s) normalizer, leave wv untouched.
-    sinks = module.sinks.reshape(1, -1, 1, 1).expand(B, Hq, Tq, -1).to(torch.float32)  # (B,Hq,Tq,S)
-    # Row-wise max over sink columns
-    sink_max = torch.amax(sinks, dim=-1)                     # (B,Hq,Tq)
-    sink_sumexp = torch.exp(sinks - sink_max.unsqueeze(-1)).sum(dim=-1)  # (B,Hq,Tq)
-
-    # Merge sinks into (m,s); wv has no sink contribution
-    new_m  = torch.maximum(m, sink_max)
-    alpha  = torch.exp(m - new_m)        # scales existing sums in new frame
-    beta   = torch.exp(sink_max - new_m) # scales sink sums in new frame
-    s = s * alpha + sink_sumexp * beta
-    m = new_m
-    del sinks, sink_max, sink_sumexp, new_m, alpha, beta
-
-    # Final normalize: out = wv / s
-    attn_out = (wv / (s.unsqueeze(-1) + eps)).to(dtype_in)   # (B,Hq,Tq,D)
-
-    # Match your return layout: transpose to (B, Tq, Hq, D)
-    attn_out = attn_out.transpose(1, 2).contiguous()
-
-    # We do not materialize attn_weights in streaming mode.
-    return attn_out, None
-
+		# This was not in the original implementation and slightly affect results; it prevents overflow in BF16/FP16
+		# when training with bsz>1 we clamp max values.
+		combined_logits = combined_logits - combined_logits.max(dim=-1, keepdim=True).values
+		probs = F.softmax(combined_logits, dim=-1, dtype=combined_logits.dtype)
+		scores = probs[..., :-1]  # we drop the sink here
+		attn_weights = nn.functional.dropout(scores, p=dropout, training=module.training)
+		attn_output = torch.matmul(attn_weights, value_states)	
+		attn_output = attn_output.transpose(1, 2).contiguous()
+	
+	#print("my_eager_attention_forward:", attn_output.shape, t.shape, attn_output.flatten()[-5:], t.flatten()[-5:], "Error:", (attn_output - t).abs().max().item(), "\n")
+	return attn_output, attn_weights
 
 
 import transformers.models.gpt_oss.modeling_gpt_oss as modeling
+modeling.GptOssExperts = MyGptOssExperts
 modeling.GptOssAttention = MyGptOssAttention
 modeling.GptOssModel = MyGptOssModel
-#modeling.eager_attention_forward = my_eager_attention_forward
+modeling.eager_attention_forward = my_eager_attention_forward #testing
 #===============================================
 
 

--- a/src/ollm/gpt_oss_attention.py
+++ b/src/ollm/gpt_oss_attention.py
@@ -1,0 +1,235 @@
+"""FlashAttention w/support for learned sinks and banded attention.
+
+This is an expanded version of the Flash Attention v2 implementation (see https://tridao.me/publications/flash2/flash2.pdf)
+which can be found at https://triton-lang.org/main/getting-started/tutorials/06-fused-attention.html.
+
+This version has been extended to support banded attention and learned attention sinks.
+"""
+
+#import pytest
+import torch
+
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+
+@triton.jit
+def _attn_fwd(
+    Q,
+    K,
+    V,
+    Sinks,
+    sm_scale,
+    M,
+    Out,  #
+    Start_q,
+    Z,
+    H,
+    N_Q_CTX,
+    N_KV_CTX,
+    HEAD_DIM: tl.constexpr,  #
+    BLOCK_M: tl.constexpr,  #
+    BLOCK_N: tl.constexpr,  #
+    BANDWIDTH: tl.constexpr,
+):
+    tl.static_assert(BLOCK_N <= HEAD_DIM)
+    start_q = tl.load(Start_q).to(tl.int32)
+    start_m = tl.program_id(0)
+    off_hz = tl.program_id(1)
+    off_z = off_hz // H
+    off_h = off_hz % H
+
+    # load attention sinks
+    if Sinks is not None:
+        sink = tl.load(Sinks + off_h).to(tl.float32)
+    else:
+        sink = 0
+
+    # initialize offsets
+    offs_m = start_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = tl.arange(0, BLOCK_N)
+    # initialize pointer to m and l
+    m_i = tl.zeros([BLOCK_M], dtype=tl.float32) + sink
+    l_i = tl.zeros([BLOCK_M], dtype=tl.float32)
+    acc = tl.zeros([BLOCK_M, HEAD_DIM], dtype=tl.float32)
+    # load scales
+    qk_scale = sm_scale
+    q = Q.load([off_z, off_h, start_m * BLOCK_M, 0]).reshape([BLOCK_M, HEAD_DIM])
+
+    if BANDWIDTH:
+        lo, hi = tl.maximum(start_q, start_q + start_m * BLOCK_M - BANDWIDTH), start_q + (start_m + 1) * BLOCK_M
+    else:
+        lo, hi = start_q, start_q + (start_m + 1) * BLOCK_M
+
+    for start_n in range(lo, hi, BLOCK_N):
+        start_n = tl.multiple_of(start_n, BLOCK_N)
+
+        mask = (start_n + offs_n)[None, :] > (start_q + offs_m)[:, None]
+
+        if BANDWIDTH:
+            too_old = (start_n + offs_n[None, :]) < (start_q + offs_m[:, None] - BANDWIDTH + 1)
+            mask = mask | too_old
+
+        k = K.load([off_z, off_h, start_n, 0]).reshape([BLOCK_N, HEAD_DIM]).T
+        qk = tl.dot(q, k, allow_tf32=False)
+
+        qk = qk * qk_scale + tl.where(mask, -1.0e6, 0.0)
+        m_ij = tl.maximum(m_i, tl.max(qk, 1))
+        qk -= m_ij[:, None]
+
+        p = tl.math.exp(qk)
+        alpha = tl.math.exp(m_i - m_ij)
+        l_ij = tl.sum(p, 1)
+        acc = acc * alpha[:, None]
+
+        v = V.load([off_z, off_h, start_n, 0]).reshape([BLOCK_N, HEAD_DIM])
+        v = v.to(tl.float32)
+        acc = tl.dot(p, v, acc, allow_tf32=False)
+
+        l_i = l_i * alpha + l_ij
+        m_i = m_ij
+
+    sink = tl.math.exp(sink - m_i)
+    z = l_i + sink
+    acc = acc / z[:, None]
+    m_i += tl.math.log(l_i)
+    m_ptrs = M + off_hz * N_Q_CTX + offs_m
+    tl.store(m_ptrs, m_i)
+    acc = acc.to(Out.dtype)[None, None, :, :]
+    Out.store([off_z, off_h, start_m * BLOCK_M, 0], acc)
+
+
+class _attention(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, q, k, v, sinks, sm_scale, bandwidth, start_q):
+        assert len(start_q) == 1
+        """
+        bs, n_ctx, n_kv_heads, repeat_kv, HEAD_DIM_Q = q.shape
+        bs, n_kv_ctx, n_kv_heads, HEAD_DIM_K = k.shape
+        bs, n_kv_ctx, n_kv_heads, HEAD_DIM_V = v.shape
+        n_heads = n_kv_heads * repeat_kv
+        q = q.view(bs, n_ctx, n_heads, HEAD_DIM_Q)
+        k = k.view(bs, n_kv_ctx, n_kv_heads, HEAD_DIM_K)
+        assert HEAD_DIM_Q == HEAD_DIM_K and HEAD_DIM_K == HEAD_DIM_V
+        assert HEAD_DIM_K in {16, 32, 64, 128, 256}
+
+        q = q.transpose(1, 2).contiguous()
+        k = k.repeat_interleave(repeat_kv, dim=2).transpose(1, 2).contiguous()
+        v = v.repeat_interleave(repeat_kv, dim=2).transpose(1, 2).contiguous()
+        """
+        #meine
+        bs, n_ctx, n_kv_ctx, n_heads, HEAD_DIM_K, HEAD_DIM_V = q.shape[0], q.shape[2], k.shape[2], 64, 64, 64
+        #print("n_ctx:", n_ctx, "n_kv_ctx:", n_kv_ctx)
+        #=====
+
+        BLOCK_M = 64
+        BLOCK_N = 64
+        m_pad_size = BLOCK_M - n_ctx % BLOCK_M if n_ctx % BLOCK_M != 0 else 0
+        # pad q to multiple of its block size in the n_ctx dimension (-2)
+        q = torch.nn.functional.pad(q, (0, 0, 0, m_pad_size))
+        n_pad_size = BLOCK_N - n_kv_ctx % BLOCK_N if n_kv_ctx % BLOCK_N != 0 else 0
+        # pad k and v to multiple of their block size in the n_kv_ctx dimension
+        k = torch.nn.functional.pad(k, (0, 0, 0, n_pad_size))
+        v = torch.nn.functional.pad(v, (0, 0, 0, n_pad_size))
+
+        o = torch.empty_like(q)
+        M = torch.empty((bs, n_heads, n_ctx + m_pad_size), device=q.device, dtype=torch.float32)
+        grid = (triton.cdiv(n_ctx, BLOCK_M), bs * n_heads, 1)
+        _attn_fwd[grid](
+            TensorDescriptor.from_tensor(q, [1, 1, BLOCK_M, HEAD_DIM_K]),
+            TensorDescriptor.from_tensor(k, [1, 1, BLOCK_N, HEAD_DIM_K]),
+            TensorDescriptor.from_tensor(v, [1, 1, BLOCK_N, HEAD_DIM_K]),
+            sinks,
+            sm_scale,
+            M,
+            TensorDescriptor.from_tensor(o, [1, 1, BLOCK_M, HEAD_DIM_K]),
+            start_q,
+            q.shape[0],
+            q.shape[1],
+            N_Q_CTX=n_ctx + m_pad_size,
+            N_KV_CTX=n_kv_ctx,
+            HEAD_DIM=HEAD_DIM_K,
+            BANDWIDTH=bandwidth,
+            BLOCK_M=BLOCK_M,
+            BLOCK_N=BLOCK_N,
+        )
+
+        ctx.save_for_backward(q, k, v, sinks, o, M, start_q)
+        ctx.sm_scale = sm_scale
+        ctx.bandwidth = bandwidth
+
+        o = o[:, :, :n_ctx, :].transpose(1, 2).contiguous()
+        #o = o.view(bs, n_ctx, n_heads * HEAD_DIM_V) #will make it in AttentionBlock
+        return o
+
+
+attention = _attention.apply
+
+
+def attention_ref(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    sinks: torch.Tensor,
+    sm_scale: float = 0.125,
+    sliding_window: int | None = None,
+    start_q: torch.LongTensor = 0,
+):
+    batch_size, num_queries, num_key_value_heads, num_key_value_groups, head_dim = query.shape
+    batch_size, num_keys, num_key_value_heads, head_dim = key.shape
+
+    sinks = sinks.view(1, num_key_value_heads, num_key_value_groups, 1, 1).float()
+    key = key.unsqueeze(3)
+    value = value.unsqueeze(3)
+
+    pos_keys = torch.arange(num_keys, device=query.device)
+    pos_queries = torch.arange(num_queries, device=query.device) + start_q
+    mask = pos_keys[None, :] > pos_queries[:, None]
+    mask = mask.float().masked_fill(mask, float("-inf"))
+
+    if sliding_window:
+        too_old = pos_keys[None, :] < (pos_queries[:, None] - sliding_window + 1)
+        mask.masked_fill_(too_old, float("-inf"))
+
+    logits = torch.einsum("bqhmd,bkhmd->bhmqk", query.float(), key.float()) * sm_scale
+    logits = logits + mask[None, None, None, :, :]
+
+    logits_max = torch.max(logits, dim=-1, keepdim=True).values
+    logits_or_sinks_max = torch.maximum(sinks, logits_max)
+    sinks = torch.exp(sinks - logits_or_sinks_max)
+    unnormalized_scores = torch.exp(logits - logits_or_sinks_max)
+    normalizer = unnormalized_scores.sum(dim=-1, keepdim=True) + sinks
+    scores = unnormalized_scores / normalizer
+
+    output = torch.einsum("bhmqk,bkhmd->bqhmd", scores, value.float())
+
+    output = output.reshape(batch_size, num_queries, num_key_value_heads * num_key_value_groups * head_dim).bfloat16()
+    return output
+
+"""
+@pytest.mark.parametrize("batch_size", [1, 2])
+@pytest.mark.parametrize("num_queries", [1, 128])
+@pytest.mark.parametrize("num_keys", [128, 32])
+@pytest.mark.parametrize("num_key_value_heads", [8])
+@pytest.mark.parametrize("num_key_value_groups", [8])
+@pytest.mark.parametrize("head_dim", [64])
+@pytest.mark.parametrize("sm_scale", [0.125])
+@pytest.mark.parametrize("sliding_window", [None, 128])
+@pytest.mark.parametrize("start_q", [0, 5])
+"""
+def test_eq(batch_size, num_queries, num_keys, num_key_value_heads, num_key_value_groups, head_dim, sm_scale, sliding_window, start_q):
+    if num_queries > num_keys:
+        pytest.skip("too many queries")
+
+    q = torch.randn(batch_size, num_queries, num_key_value_heads, num_key_value_groups, head_dim).bfloat16().cuda()
+    k = torch.randn(batch_size, num_keys, num_key_value_heads, head_dim).bfloat16().cuda()
+    v = torch.randn(batch_size, num_keys, num_key_value_heads, head_dim).bfloat16().cuda()
+    sinks = torch.randn(num_key_value_heads * num_key_value_groups).bfloat16().cuda()
+
+    start_q = torch.tensor([start_q], dtype=torch.int32).cuda()
+
+    o1 = attention(q, k, v, sinks, sm_scale, sliding_window, start_q)
+    o2 = attention_ref(q, k, v, sinks, sm_scale, sliding_window, start_q)
+
+    torch.testing.assert_close(o1, o2)

--- a/src/ollm/inference.py
+++ b/src/ollm/inference.py
@@ -3,6 +3,7 @@ import torch
 from transformers import AutoTokenizer
 from .utils import Stats, file_get_contents
 from .gds_loader import GDSWeights
+from .kvcache import KVCache
 from . import llama
 from . import gpt_oss
 
@@ -72,36 +73,9 @@ class Inference:
 	def offload_layers_to_cpu(self, **args):
 		self.model.offload_layers_to_cpu(**args)
 
-
-#==============================================================================================
-
-if __name__ == "__main__":
-	device = torch.device("cuda:0")
-	llama.loader = GDSWeights("/home/mega4alik/ssd/gds_export/manifest.json")
-	stats = Stats()
-	if 1==0: #prepare model without layers weights
-		model_id = "meta-llama/Llama-3.2-1B-Instruct"
-		tokenizer = AutoTokenizer.from_pretrained(model_id)
-		tokenizer.pad_token = tokenizer.eos_token
-		model = MyLlamaForCausalLM.from_pretrained(model_id, torch_dtype=torch.float16, device_map="cpu", low_cpu_mem_usage=True) #cpu | meta, dtype=should be bfloat16
-		model.clean_layers_weights()
-		model.save_pretrained("./models/llama3-1B") #saving model without layers weights
-		tokenizer.save_pretrained("./models/llama3-1B"); exit()
 	
-	elif 2==2:
-		model_id = "./models/llama3-1B-chat"
-		print("loading model:", model_id)
-		tokenizer = AutoTokenizer.from_pretrained(model_id)
-		model = MyLlamaForCausalLM.from_pretrained(model_id, torch_dtype=torch.float16, device_map="cpu", low_cpu_mem_usage=True, ignore_mismatched_sizes=True)
-		model.clean_layers_weights()
-		model.eval()
-		model.cuda()
-		inference_chat()
-
-
-
-
-
-
-
-
+	def DiskCache(self, cache_dir="./kvcache"):
+		if self.model_id=="gpt-oss-20B":
+			print("gpt-oss-20B DiskCache is not supported at the moment. using default DynamicCache instead")
+		else:
+			return KVCache(cache_dir=cache_dir, stats=self.stats) #config=?

--- a/src/ollm/kvcache.py
+++ b/src/ollm/kvcache.py
@@ -1,9 +1,9 @@
 import os, time, shutil
 import torch
-from transformers import Cache, DynamicCache
+from transformers import DynamicCache
 from typing import Callable, Optional, Tuple, Union, Dict, Any, Iterable, List
 
-class KVCache(DynamicCache):
+class KVCache(DynamicCache): #2.0
 	def __init__(self, cache_dir="./kv_cache", stats=None):
 		super().__init__()
 		self.cache_folder = os.path.join(cache_dir, "kv_cache")
@@ -12,6 +12,47 @@ class KVCache(DynamicCache):
 		os.makedirs(self.cache_folder)
 		self.stats = stats
 
+	def update(
+		self,
+		key_states: torch.Tensor,
+		value_states: torch.Tensor,
+		layer_idx: int,
+		cache_kwargs: Optional[Dict[str, Any]] = None,
+	) -> Tuple[torch.Tensor, torch.Tensor]:
+		tensors = self.load_from_disk(layer_idx)
+		if tensors is not None:
+			self.layers[layer_idx].keys, self.layers[layer_idx].values = tensors
+			if layer_idx < len(self.key_cache2):
+				self.layers[layer_idx].keys = torch.cat([self.layers[layer_idx].keys, self.key_cache2[layer_idx]], dim=-2)
+				self.layers[layer_idx].values = torch.cat([self.layers[layer_idx].values, self.value_cache2[layer_idx]], dim=-2)
+				self.key_cache2[layer_idx] = torch.cat([self.key_cache2[layer_idx], key_states], dim=-2)
+				self.value_cache2[layer_idx] = torch.cat([self.value_cache2[layer_idx], value_states], dim=-2)				
+			else:
+				self.key_cache2.append(key_states)
+				self.value_cache2.append(value_states)
+		
+		out = super().update(key_states, value_states, layer_idx, cache_kwargs) #tuple of (self.key_cache[layer_idx], self.value_cache[layer_idx])		
+		if tensors is None: self.save_to_disk(out, layer_idx) #save only first time cause it's slow to save
+		self.layers[layer_idx].keys, self.layers[layer_idx].values = None, None
+		return out
+
+	def load_from_disk(self, layer_idx, device="cuda:0"):
+		path = f"{self.cache_folder}/layer_{layer_idx}.pt"
+		if not os.path.exists(path): return None
+		t1 = time.perf_counter()
+		tensors = torch.load(path, map_location=device)
+		if self.stats: self.stats.set("kvload", t1)
+		return tensors
+
+	def save_to_disk(self, tensors, layer_idx):
+		t1 = time.perf_counter()
+		path = f"{self.cache_folder}/layer_{layer_idx}.pt"
+		tensors = (tensors[0].cpu(), tensors[1].cpu())
+		torch.save(tensors, path)
+		if self.stats: self.stats.set("kvsave", t1)
+
+
+class KVCache_legacy(DynamicCache):
 	def update(
 		self,
 		key_states: torch.Tensor,
@@ -35,18 +76,3 @@ class KVCache(DynamicCache):
 		if tensors is None: self.save_to_disk(out, layer_idx) #save only first time cause it's slow to save
 		self.key_cache[layer_idx], self.value_cache[layer_idx] = torch.empty(0), torch.empty(0)
 		return out
-
-	def load_from_disk(self, layer_idx, device="cuda:0"):
-		path = f"{self.cache_folder}/layer_{layer_idx}.pt"
-		if not os.path.exists(path): return None
-		t1 = time.perf_counter()
-		tensors = torch.load(path, map_location=device)
-		if self.stats: self.stats.set("kvload", t1)
-		return tensors
-
-	def save_to_disk(self, tensors, layer_idx):
-		t1 = time.perf_counter()
-		path = f"{self.cache_folder}/layer_{layer_idx}.pt"
-		tensors = (tensors[0].cpu(), tensors[1].cpu())
-		torch.save(tensors, path)
-		if self.stats: self.stats.set("kvsave", t1)

--- a/src/ollm/kvcache.py
+++ b/src/ollm/kvcache.py
@@ -3,7 +3,7 @@ import torch
 from transformers import DynamicCache
 from typing import Callable, Optional, Tuple, Union, Dict, Any, Iterable, List
 
-class KVCache(DynamicCache): #2.0
+class KVCache(DynamicCache):
 	def __init__(self, cache_dir="./kv_cache", stats=None):
 		super().__init__()
 		self.cache_folder = os.path.join(cache_dir, "kv_cache")


### PR DESCRIPTION
- Llama3 custom chunked attention replaced with flash-attention2 for stability
- gpt-oss-20B flash-attention-like implementation added to reduce VRAM usage
- gpt-oss-20B chunked MLP added to reduce VRAM usage
- KVCache is replaced with DiskCache.
- Latest transformers (4.56.1) library is now supported
- Important! If you are seeing repetitive outputs with Llama3 or gpt-oss models, upgrade to the newest 0.3.0 version by `pip install ollm --upgrade`
